### PR TITLE
Fix undefined company variable in SupportBot

### DIFF
--- a/BRAIN/SupportBot.php
+++ b/BRAIN/SupportBot.php
@@ -366,7 +366,7 @@ Answer the users question.$MentionSearchResults
 Respond **strictly with just a JSON object** containing:
 EOD;
 if (!empty($CompanyName)) {
-    $PromptAnswerGeneralStarting .= "\n(you are acting as the support bot for company: $company)";
+    $PromptAnswerGeneralStarting .= "\n(you are acting as the support bot for company: {$CompanyName})";
 }
 
 if ($singleTable) {


### PR DESCRIPTION
## SUMMARY
- replace undefined `$company` variable with `$CompanyName`

## TESTING
- `php -l BRAIN/SupportBot.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7cceac3508329b79eecd96ca28c89