### PR TITLE
🐛 fix SupportBot array handling

### DIFF
--- a/BRAIN/SupportBot.php
+++ b/BRAIN/SupportBot.php
@@ -47,7 +47,12 @@ function extractTextFromResponse(array $response): string {
     return trim($buf);
 }
 
-function extractJsonFromCodeBlock(string $text): string {
+function extractJsonFromCodeBlock($text): string {
+    if (is_array($text)) {
+        $text = json_encode($text);
+    } else {
+        $text = (string)$text;
+    }
     $text = trim($text);
     if (preg_match('/```(?:json)?\s*(\{[\s\S]*\})\s*```/i', $text, $m)) {
         return $m[1];


### PR DESCRIPTION
## 🛠️ SUMMARY
- allow SupportBot's JSON extractor to accept arrays by normalizing input

## ✅ TESTING
- `php -l BRAIN/SupportBot.php`
- `php BRAIN/SupportBot.php` *(fails: Connection to database couldn't be made)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cf4d89f48329b106d48d767c4709