### PR TITLE
Fix SupportBot final response parsing

### DIFF
--- a/BRAIN/SupportBot.php
+++ b/BRAIN/SupportBot.php
@@ -448,10 +448,11 @@ $entries = [];
 if ($resp2 !== false) {
     $dec2 = json_decode($resp2, true);
     if (is_array($dec2)) {
-        $tmp = extractJsonFromCodeBlock($tmp);
-        $js = json_decode($tmp, true);
+        $text2 = extractTextFromResponse($dec2);
+        $jsonText = extractJsonFromCodeBlock($text2);
+        $js = json_decode($jsonText, true);
         if (is_array($js)) {
-            $message = (string)($js['message'] ?? $js['answer'] ?? $tmp);
+            $message = (string)($js['message'] ?? $js['answer'] ?? $jsonText);
             if ($singleTable) {
                 $ids = $js['idpks'] ?? [];
                 if (is_array($ids)) {
@@ -475,7 +476,7 @@ if ($resp2 !== false) {
                 }
             }
         } else {
-            $message = $tmp;
+            $message = $jsonText;
         }
     }
 }


### PR DESCRIPTION
## 🔧 FIX SUPPORT BOT RESPONSE HANDLING
- correctly parse the second API response before returning data
- avoid reusing search term JSON as final message

## ✅ TESTING
- `php -l BRAIN/SupportBot.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7d2d5e7a88329bdfd3ac4f3e0398b